### PR TITLE
Added Waypoint Support (TomTom and Built-In) and updated accuracy for Continent Pins

### DIFF
--- a/IPInstanceDB.lua
+++ b/IPInstanceDB.lua
@@ -188,24 +188,36 @@ IPUIInstanceMapDB = {
 
 	[1180]={"Ny'alotha, The Waking City", 2, 120, 8},
 
-    --[[ Shadowlands ]]--
+	--[[ Shadowlands ]]--
 
-    [1182]={"The Necrotic Wake", 1, 60, 9},
-    [1186]={"Spires of Ascension", 1, 60, 9},
-    [1183]={"Plaguefall", 1, 60, 9},
-    [1187]={"Theater of Pain", 1, 60, 9},
-    [1184]={"Mists of Tirna Scithe", 1, 60, 9},
-    [1188]={"De Other Side", 1, 60, 9},
+	[1182]={"The Necrotic Wake", 1, 60, 9},
+	[1186]={"Spires of Ascension", 1, 60, 9},
+	[1183]={"Plaguefall", 1, 60, 9},
+	[1187]={"Theater of Pain", 1, 60, 9},
+	[1184]={"Mists of Tirna Scithe", 1, 60, 9},
+	[1188]={"De Other Side", 1, 60, 9},
 
-    [1185]={"Halls of Atonement", 1, 60, 9},
-    [1189]={"Sanguine Depths", 1, 60, 9},
-		
-		[1194]={"Tazavesh, the Veiled Market", 1, 60, 9},
+	[1185]={"Halls of Atonement", 1, 60, 9},
+	[1189]={"Sanguine Depths", 1, 60, 9},
+	
+	[1194]={"Tazavesh, the Veiled Market", 1, 60, 9},
 
-    [1190]={"Castle Nathria", 2, 60, 9},
-    [1193]={"Sanctum of Domination", 2, 60, 9},
-    [1195]={"Sepulcher of the First Ones", 2, 60, 9},
-
+	[1190]={"Castle Nathria", 2, 60, 9},
+	[1193]={"Sanctum of Domination", 2, 60, 9},
+	[1195]={"Sepulcher of the First Ones", 2, 60, 9},
+	
+	--[[ Dragon Isles ]]--
+	
+	[1196]={"Brackenhide Hollow", 1, 60, 10},
+	[1198]={"The Nokhud Offensive", 1, 60, 10},
+	[1199]={"Neltharus", 1, 60, 10},	
+	[1201]={"Algeth'ar Academy", 1, 60, 10},
+	[1202]={"Ruby Life Pools", 1, 60, 10},
+	[1203]={"The Azure Vault", 1, 60, 10},
+	[1204]={"Halls of Infusion", 1, 60, 10},
+	
+	[1200]={"Vault of the Incarnates", 2, 60, 10},
+	
 }
 
 IPUIInstanceFactionSpecificDB = {

--- a/IPInstanceDB.lua
+++ b/IPInstanceDB.lua
@@ -199,8 +199,12 @@ IPUIInstanceMapDB = {
 
     [1185]={"Halls of Atonement", 1, 60, 9},
     [1189]={"Sanguine Depths", 1, 60, 9},
+		
+		[1194]={"Tazavesh, the Veiled Market", 1, 60, 9},
 
     [1190]={"Castle Nathria", 2, 60, 9},
+    [1193]={"Sanctum of Domination", 2, 60, 9},
+    [1195]={"Sepulcher of the First Ones", 2, 60, 9},
 
 }
 

--- a/IPInstancePortalPinTemplate.lua
+++ b/IPInstancePortalPinTemplate.lua
@@ -1,78 +1,78 @@
 IPInstancePortalMapDataProviderMixin = CreateFromMixins(MapCanvasDataProviderMixin);
 
 function IPInstancePortalMapDataProviderMixin:RemoveAllData()
-	self:GetMap():RemoveAllPinsByTemplate("IPInstancePortalPinTemplate");
+  self:GetMap():RemoveAllPinsByTemplate("IPInstancePortalPinTemplate");
 end
 
 function IPInstancePortalMapDataProviderMixin:OnShow()
-	self:RegisterEvent("CVAR_UPDATE");
+  self:RegisterEvent("CVAR_UPDATE");
 end
 
 function IPInstancePortalMapDataProviderMixin:OnHide()
-	self:UnregisterEvent("CVAR_UPDATE");
+  self:UnregisterEvent("CVAR_UPDATE");
 end
 
 function IPInstancePortalMapDataProviderMixin:OnEvent(event, ...)
-	if event == "CVAR_UPDATE" then
-		local eventName, value = ...;
-		if eventName == "INSTANCE_PORTAL_REFRESH" then
-			self:RefreshAllData();
-		end
-	end
+  if event == "CVAR_UPDATE" then
+    local eventName, value = ...;
+    if eventName == "INSTANCE_PORTAL_REFRESH" then
+      self:RefreshAllData();
+    end
+  end
 end
 
 function IPInstancePortalMapDataProviderMixin:RefreshAllData(fromOnShow)
-	self:RemoveAllData();
-	IPUIPrintDebug("IPInstancePortalMapDataProviderMixin:RefreshAllData")
+  self:RemoveAllData();
+  IPUIPrintDebug("IPInstancePortalMapDataProviderMixin:RefreshAllData")
 
-	local trackOnZones = IPUITrackInstancePortals
-	local trackOnContinents = IPUITrackInstancePortalsOnContinents
+  local trackOnZones = IPUITrackInstancePortals
+  local trackOnContinents = IPUITrackInstancePortalsOnContinents
 
-	local mapID = self:GetMap():GetMapID();
-	IPUIPrintDebug("Map ID = "..mapID)
+  local mapID = self:GetMap():GetMapID();
+  IPUIPrintDebug("Map ID = "..mapID)
 
-	local dungeonEntrances = C_EncounterJournal.GetDungeonEntrancesForMap(mapID)
+  local dungeonEntrances = C_EncounterJournal.GetDungeonEntrancesForMap(mapID)
 
-	for i, dungeonEntranceInfo in ipairs(dungeonEntrances) do
-		IPUIPrintDebug("Atlas = ("..dungeonEntranceInfo["position"]["x"]..","..dungeonEntranceInfo["position"]["y"]..")")
-	end
+  for i, dungeonEntranceInfo in ipairs(dungeonEntrances) do
+    IPUIPrintDebug("Atlas = ("..dungeonEntranceInfo["position"]["x"]..","..dungeonEntranceInfo["position"]["y"]..")")
+  end
 
-	if IPUIPinDB[mapID] then
-		local count = #IPUIPinDB[mapID]
-		local isContinent = false;
-		for i = 1, #IPUIContinentMapDB do
-			if IPUIContinentMapDB[i] == mapID then
-				isContinent = true;
-			end
-		end
-  
-        if not (isContinent) then
-            return
+  if IPUIPinDB[mapID] then
+    local count = #IPUIPinDB[mapID]
+    local isContinent = false;
+    for i = 1, #IPUIContinentMapDB do
+      if IPUIContinentMapDB[i] == mapID then
+        isContinent = true;
+      end
+    end
+
+    if not (isContinent) then
+      return
+    end
+
+    IPUIPrintDebug("Map is continent = "..(isContinent and 'true' or 'false'))
+    local playerFaction = UnitFactionGroup("player")
+
+    for i = 1, count do
+      local entranceInfo = IPUIGetEntranceInfoForMapID(mapID, i);
+
+      if entranceInfo then
+        local factionWhitelist = entranceInfo["factionWhitelist"];
+
+        local isWhitelisted = true;
+
+        if factionWhitelist and not (factionWhitelist == playerFaction) then
+          isWhitelisted = false
         end
-		
-		IPUIPrintDebug("Map is continent = "..(isContinent and 'true' or 'false'))
-		local playerFaction = UnitFactionGroup("player")
 
-		for i = 1, count do
-			local entranceInfo = IPUIGetEntranceInfoForMapID(mapID, i);
-			
-			if entranceInfo then
-				local factionWhitelist = entranceInfo["factionWhitelist"];
-				
-				local isWhitelisted = true;
-				
-				if factionWhitelist and not (factionWhitelist == playerFaction) then
-					isWhitelisted = false
-				end
-
-				if (isContinent and trackOnContinents) or (not isContinent and trackOnZones) then
-					if (isWhitelisted) then
-						self:GetMap():AcquirePin("IPInstancePortalPinTemplate", entranceInfo);
-					end
-				end
-			end
-		end
-	end
+        if (isContinent and trackOnContinents) or (not isContinent and trackOnZones) then
+          if (isWhitelisted) then
+            self:GetMap():AcquirePin("IPInstancePortalPinTemplate", entranceInfo);
+          end
+        end
+      end
+    end
+  end
 
 end
 
@@ -80,88 +80,89 @@ end
 IPInstancePortalProviderPinMixin = BaseMapPoiPinMixin:CreateSubPin("PIN_FRAME_LEVEL_DUNGEON_ENTRANCE");
 
 function IPInstancePortalProviderPinMixin:OnAcquired(dungeonEntranceInfo) -- override
-	BaseMapPoiPinMixin.OnAcquired(self, dungeonEntranceInfo);
+  BaseMapPoiPinMixin.OnAcquired(self, dungeonEntranceInfo);
 
-	self.hub = dungeonEntranceInfo.hub
-	self.tier = dungeonEntranceInfo.tier;
-	self.journalInstanceID = dungeonEntranceInfo.journalInstanceID;
+  self.hub = dungeonEntranceInfo.hub
+  self.tier = dungeonEntranceInfo.tier;
+  self.journalInstanceID = dungeonEntranceInfo.journalInstanceID;
 end
 
+-- local function for "Add Waypoints" with the feature to "force" Built-In Waypoint System, just set "useTomTom" to false or leave it blank
 local function AddWaypoint(mapID, x, y, title, useTomTom)
-	if useTomTom and TomTom then
-		title = title or "Waypoint"
-		TomTom:AddWaypoint(mapID, x, y, {
-			title = title,
-			persistent = false,
-			minimap = true,
-			world = true,
-			from = "InstancePortals"
-		})
-	else
-		if C_Map.CanSetUserWaypointOnMap(mapID) then
-			local vector = CreateVector2D(x, y)
-			local mapPoint = UiMapPoint.CreateFromVector2D(mapID, vector)
-			C_Map.SetUserWaypoint(mapPoint)
-			local shouldSuperTrack = not C_SuperTrack.IsSuperTrackingUserWaypoint();
-			C_SuperTrack.SetSuperTrackedUserWaypoint(shouldSuperTrack)
-			if shouldSuperTrack then
-				PlaySound(SOUNDKIT.UI_MAP_WAYPOINT_SUPER_TRACK_ON, nil, SOUNDKIT_ALLOW_DUPLICATES);
-			else
-				PlaySound(SOUNDKIT.UI_MAP_WAYPOINT_SUPER_TRACK_OFF, nil, SOUNDKIT_ALLOW_DUPLICATES);
-			end
-		end
-	end
+  if (useTomTom == true) and TomTom then
+    title = title or "Waypoint"
+    TomTom:AddWaypoint(mapID, x, y, {
+      title = title,
+      persistent = false,
+      minimap = true,
+      world = true,
+      from = "InstancePortals"
+    })
+  else -- if TomTom is not installed or useTomTom is false you the Built-In Waypoint System
+    if C_Map.CanSetUserWaypointOnMap(mapID) then
+      local vector = CreateVector2D(x, y)
+      local mapPoint = UiMapPoint.CreateFromVector2D(mapID, vector)
+      C_Map.SetUserWaypoint(mapPoint)
+      local shouldSuperTrack = not C_SuperTrack.IsSuperTrackingUserWaypoint();
+      C_SuperTrack.SetSuperTrackedUserWaypoint(shouldSuperTrack)
+      if shouldSuperTrack then
+        PlaySound(SOUNDKIT.UI_MAP_WAYPOINT_SUPER_TRACK_ON, nil, SOUNDKIT_ALLOW_DUPLICATES);
+      else
+        PlaySound(SOUNDKIT.UI_MAP_WAYPOINT_SUPER_TRACK_OFF, nil, SOUNDKIT_ALLOW_DUPLICATES);
+      end
+    end
+  end
 end
 
 function IPInstancePortalProviderPinMixin:OnClick(button)
-	local useWaypoints = true
-	local useTomTom = true
-	local wp_mapid, wp_x, wp_y, wp_name	
-	useTomTom = useTomTom and (TomTom ~= nil) or false
+  local useWaypoints = true
+  local useTomTom = true
+  local wp_mapid, wp_x, wp_y, wp_name
+  useTomTom = useTomTom and (TomTom ~= nil) or false
 
-	if self.hub == 0 then	
-		if ((button == "RightButton") and (useWaypoints == true)) then
-			local uiMapID = self:GetMap():GetMapID();
-			if not uiMapID then return end
-			local mapChildren = C_Map.GetMapChildrenInfo(uiMapID, Enum.UIMapType.Zone)
-			if ( (type(mapChildren) ~= 'table') or (#mapChildren < 1) ) then return end
-			local journalInstanceID = self.journalInstanceID
-			if not journalInstanceID then return end			
+  if self.hub == 0 then
+    if ((button == "RightButton") and (useWaypoints == true)) then
+      local uiMapID = self:GetMap():GetMapID();
+      if not uiMapID then return end
+      local mapChildren = C_Map.GetMapChildrenInfo(uiMapID, Enum.UIMapType.Zone) -- get current map children
+      if ( (type(mapChildren) ~= 'table') or (#mapChildren < 1) ) then return end -- mapChildren is not table or empty
+      local journalInstanceID = self.journalInstanceID
+      if not journalInstanceID then return end
 
-			for _, childMapInfo in ipairs(mapChildren) do
-				if childMapInfo then
-					local dungeonEntrances = C_EncounterJournal.GetDungeonEntrancesForMap(childMapInfo.mapID);
-					
-					for _, dungeonEntranceInfo in ipairs(dungeonEntrances) do
-						if dungeonEntranceInfo.journalInstanceID == journalInstanceID then
-							wp_mapid = childMapInfo.mapID
-							wp_x = dungeonEntranceInfo.position.x
-							wp_y = dungeonEntranceInfo.position.y
-							wp_name = dungeonEntranceInfo.name or "Waypoint"
+      for _, childMapInfo in ipairs(mapChildren) do -- enum "current" map for children
+        if childMapInfo then
+          local dungeonEntrances = C_EncounterJournal.GetDungeonEntrancesForMap(childMapInfo.mapID); -- get Dungeon Entrances for current Map
+          for _, dungeonEntranceInfo in ipairs(dungeonEntrances) do -- enum "dungeonEntrances"
+            if dungeonEntranceInfo.journalInstanceID == journalInstanceID then -- found Dungeon with matching instanceID
+              wp_mapid = childMapInfo.mapID
+              wp_x = dungeonEntranceInfo.position.x
+              wp_y = dungeonEntranceInfo.position.y
+              wp_name = dungeonEntranceInfo.name or "Waypoint"
 						end
-					end
+          end
 				end
-			end
-			
-			-- if no "dungeonEntranceInfo" is found, use Pin itself as Source
-			if (not wp_mapid) then
-				wp_mapid = self:GetMap():GetMapID();
-				wp_x, wp_y = self:GetPosition()
-				wp_name = self.name or "Waypoint"
-			end
-		else -- not "RightButton" or useWaypoints is false
-			EncounterJournal_LoadUI();
-			EncounterJournal_OpenJournal(nil, self.journalInstanceID)
-		end
-	else
-		if ((button == "RightButton") and (useWaypoints == true)) then
-			wp_mapid = self:GetMap():GetMapID();
-			wp_x, wp_y = self:GetPosition()
-			wp_name = self.name or "Waypoint"
-		end
-	end
-	
-	if ((button == "RightButton") and (useWaypoints == true)) and wp_mapid and wp_x and wp_y and wp_name then
-		AddWaypoint(wp_mapid, wp_x, wp_y, wp_name, useTomTom)
-	end
+      end
+
+      
+      if (not wp_mapid) then -- if no "Dungeon Entrance" is found, try to use Map Pin itself as Source
+        wp_mapid = self:GetMap():GetMapID();
+        wp_x, wp_y = self:GetPosition()
+        wp_name = self.name or "Waypoint"
+      end
+    else -- not "RightButton" or "useWaypoints" is false then just open Encounter Journal
+      EncounterJournal_LoadUI();
+      EncounterJournal_OpenJournal(nil, self.journalInstanceID)
+    end
+  else -- if self.hub ~= 0, try to use Map Pin itself as Source
+    if ((button == "RightButton") and (useWaypoints == true)) then
+      wp_mapid = self:GetMap():GetMapID();
+      wp_x, wp_y = self:GetPosition()
+      wp_name = self.name or "Waypoint"
+    end
+  end
+
+	-- check for all needed Variables and Add Waypoint if all Variables are present
+  if ((button == "RightButton") and (useWaypoints == true)) and wp_mapid and wp_x and wp_y and wp_name then
+    AddWaypoint(wp_mapid, wp_x, wp_y, wp_name, useTomTom)
+  end
 end

--- a/IPInstancePortalPinTemplate.lua
+++ b/IPInstancePortalPinTemplate.lua
@@ -1,90 +1,79 @@
 IPInstancePortalMapDataProviderMixin = CreateFromMixins(MapCanvasDataProviderMixin);
 
 function IPInstancePortalMapDataProviderMixin:RemoveAllData()
-  self:GetMap():RemoveAllPinsByTemplate("IPInstancePortalPinTemplate");
+	self:GetMap():RemoveAllPinsByTemplate("IPInstancePortalPinTemplate");
 end
 
 function IPInstancePortalMapDataProviderMixin:OnShow()
-  self:RegisterEvent("CVAR_UPDATE");
+	self:RegisterEvent("CVAR_UPDATE");
 end
 
 function IPInstancePortalMapDataProviderMixin:OnHide()
-  self:UnregisterEvent("CVAR_UPDATE");
+	self:UnregisterEvent("CVAR_UPDATE");
 end
 
 function IPInstancePortalMapDataProviderMixin:OnEvent(event, ...)
-  if event == "CVAR_UPDATE" then
-    local eventName, value = ...;
-    if eventName == "INSTANCE_PORTAL_REFRESH" then
-      self:RefreshAllData();
-    end
-  end
+	if event == "CVAR_UPDATE" then
+		local eventName, value = ...;
+		if eventName == "INSTANCE_PORTAL_REFRESH" then
+			self:RefreshAllData();
+		end
+	end
 end
 
 function IPInstancePortalMapDataProviderMixin:RefreshAllData(fromOnShow)
-  self:RemoveAllData();
-  IPUIPrintDebug("IPInstancePortalMapDataProviderMixin:RefreshAllData")
+	self:RemoveAllData();
+	IPUIPrintDebug("IPInstancePortalMapDataProviderMixin:RefreshAllData")
 
-  local trackOnZones = IPUITrackInstancePortals
-  local trackOnContinents = IPUITrackInstancePortalsOnContinents
+	local trackOnZones = IPUITrackInstancePortals
+	local trackOnContinents = IPUITrackInstancePortalsOnContinents
 
-  local mapID = self:GetMap():GetMapID();
-  IPUIPrintDebug("Map ID = "..mapID)
+	local mapID = self:GetMap():GetMapID();
+	IPUIPrintDebug("Map ID = "..mapID)
 
-  local dungeonEntrances = C_EncounterJournal.GetDungeonEntrancesForMap(mapID)
+	local dungeonEntrances = C_EncounterJournal.GetDungeonEntrancesForMap(mapID)
 
-  for i, dungeonEntranceInfo in ipairs(dungeonEntrances) do
-    IPUIPrintDebug("Atlas = ("..dungeonEntranceInfo["position"]["x"]..","..dungeonEntranceInfo["position"]["y"]..")")
-  end
+	for i, dungeonEntranceInfo in ipairs(dungeonEntrances) do
+		IPUIPrintDebug("Atlas = ("..dungeonEntranceInfo["position"]["x"]..","..dungeonEntranceInfo["position"]["y"]..")")
+	end
 
-  if IPUIPinDB[mapID] then
-    local count = #IPUIPinDB[mapID]
-    local isContinent = false;
-    for i = 1, #IPUIContinentMapDB do
-      if IPUIContinentMapDB[i] == mapID then
-        isContinent = true;
-      end
-    end
-
-    if not (isContinent) then
-      return
-    end
-
-    IPUIPrintDebug("Map is continent = "..(isContinent and 'true' or 'false'))
-    local playerFaction = UnitFactionGroup("player")
-
-    for i = 1, count do
-      local entranceInfo = IPUIGetEntranceInfoForMapID(mapID, i);
-
-      if entranceInfo then
-        local factionWhitelist = entranceInfo["factionWhitelist"];
-
-        local isWhitelisted = true;
-
-        if factionWhitelist and not (factionWhitelist == playerFaction) then
-          isWhitelisted = false
+	if IPUIPinDB[mapID] then
+		local count = #IPUIPinDB[mapID]
+		local isContinent = false;
+		for i = 1, #IPUIContinentMapDB do
+			if IPUIContinentMapDB[i] == mapID then
+				isContinent = true;
+			end
+		end
+  
+        if not (isContinent) then
+            return
         end
+		
+		IPUIPrintDebug("Map is continent = "..(isContinent and 'true' or 'false'))
+		local playerFaction = UnitFactionGroup("player")
 
-        if (isContinent and trackOnContinents) or (not isContinent and trackOnZones) then
-          if (isWhitelisted) then
-            self:GetMap():AcquirePin("IPInstancePortalPinTemplate", entranceInfo);
-          end
-        end
-      end
-    end
-  end
+		for i = 1, count do
+			local entranceInfo = IPUIGetEntranceInfoForMapID(mapID, i);
+			
+			if entranceInfo then
+				local factionWhitelist = entranceInfo["factionWhitelist"];
+				
+				local isWhitelisted = true;
+				
+				if factionWhitelist and not (factionWhitelist == playerFaction) then
+					isWhitelisted = false
+				end
 
-end
+				if (isContinent and trackOnContinents) or (not isContinent and trackOnZones) then
+					if (isWhitelisted) then
+						self:GetMap():AcquirePin("IPInstancePortalPinTemplate", entranceInfo);
+					end
+				end
+			end
+		end
+	end
 
---[[ Pin ]]--
-IPInstancePortalProviderPinMixin = BaseMapPoiPinMixin:CreateSubPin("PIN_FRAME_LEVEL_DUNGEON_ENTRANCE");
-
-function IPInstancePortalProviderPinMixin:OnAcquired(dungeonEntranceInfo) -- override
-  BaseMapPoiPinMixin.OnAcquired(self, dungeonEntranceInfo);
-
-  self.hub = dungeonEntranceInfo.hub
-  self.tier = dungeonEntranceInfo.tier;
-  self.journalInstanceID = dungeonEntranceInfo.journalInstanceID;
 end
 
 -- local function for "Add Waypoints" with the feature to "force" Built-In Waypoint System, just set "useTomTom" to false or leave it blank
@@ -114,23 +103,42 @@ local function AddWaypoint(mapID, x, y, title, useTomTom)
   end
 end
 
+
+--[[ Pin ]]--
+IPInstancePortalProviderPinMixin = BaseMapPoiPinMixin:CreateSubPin("PIN_FRAME_LEVEL_DUNGEON_ENTRANCE");
+
+function IPInstancePortalProviderPinMixin:OnAcquired(dungeonEntranceInfo) -- override
+	BaseMapPoiPinMixin.OnAcquired(self, dungeonEntranceInfo);
+
+	self.hub = dungeonEntranceInfo.hub
+	self.tier = dungeonEntranceInfo.tier;
+	self.journalInstanceID = dungeonEntranceInfo.journalInstanceID;
+end
+
 function IPInstancePortalProviderPinMixin:OnClick(button)
-  local useWaypoints = true
+	local Debug = false
+	local useWaypoints = true
   local useTomTom = true
   local wp_mapid, wp_x, wp_y, wp_name
   useTomTom = useTomTom and (TomTom ~= nil) or false
 
+	if Debug and Debug == true then print("button: "..button) end
+	if Debug and Debug == true then print("self.hub: "..self.hub) end
+	
   if self.hub == 0 then
-    if ((button == "RightButton") and (useWaypoints == true)) then
+    if (button == "LeftButton" and IsShiftKeyDown() and useWaypoints == true) then
+			if IsControlKeyDown() then useTomTom = false end
       local uiMapID = self:GetMap():GetMapID();
-      if not uiMapID then return end
+			if Debug and Debug == true then print("uiMapID: "..uiMapID) end
+      if not uiMapID then return end			
       local mapChildren = C_Map.GetMapChildrenInfo(uiMapID, Enum.UIMapType.Zone) -- get current map children
       if ( (type(mapChildren) ~= 'table') or (#mapChildren < 1) ) then return end -- mapChildren is not table or empty
       local journalInstanceID = self.journalInstanceID
+			if Debug and Debug == true then print("journalInstanceID: "..journalInstanceID) end
       if not journalInstanceID then return end
 
       for _, childMapInfo in ipairs(mapChildren) do -- enum "current" map for children
-        if childMapInfo then
+        if childMapInfo and childMapInfo.mapID then
           local dungeonEntrances = C_EncounterJournal.GetDungeonEntrancesForMap(childMapInfo.mapID); -- get Dungeon Entrances for current Map
           for _, dungeonEntranceInfo in ipairs(dungeonEntrances) do -- enum "dungeonEntrances"
             if dungeonEntranceInfo.journalInstanceID == journalInstanceID then -- found Dungeon with matching instanceID
@@ -138,6 +146,12 @@ function IPInstancePortalProviderPinMixin:OnClick(button)
               wp_x = dungeonEntranceInfo.position.x
               wp_y = dungeonEntranceInfo.position.y
               wp_name = dungeonEntranceInfo.name or "Waypoint"
+							if Debug and Debug == true then
+								print("childMapInfo.mapID: "..childMapInfo.mapID)
+								print("dungeonEntranceInfo.name: "..dungeonEntranceInfo.name)
+								print("dungeonEntranceInfo.position.x: "..dungeonEntranceInfo.position.x)
+								print("dungeonEntranceInfo.position.y: "..dungeonEntranceInfo.position.y)
+							end
 						end
           end
 				end
@@ -154,7 +168,7 @@ function IPInstancePortalProviderPinMixin:OnClick(button)
       EncounterJournal_OpenJournal(nil, self.journalInstanceID)
     end
   else -- if self.hub ~= 0, try to use Map Pin itself as Source
-    if ((button == "RightButton") and (useWaypoints == true)) then
+    if (button == "LeftButton" and IsShiftKeyDown() and useWaypoints == true) then
       wp_mapid = self:GetMap():GetMapID();
       wp_x, wp_y = self:GetPosition()
       wp_name = self.name or "Waypoint"
@@ -162,7 +176,7 @@ function IPInstancePortalProviderPinMixin:OnClick(button)
   end
 
 	-- check for all needed Variables and Add Waypoint if all Variables are present
-  if ((button == "RightButton") and (useWaypoints == true)) and wp_mapid and wp_x and wp_y and wp_name then
+  if (button == "LeftButton" and IsShiftKeyDown() and useWaypoints == true) and wp_mapid and wp_x and wp_y and wp_name then
     AddWaypoint(wp_mapid, wp_x, wp_y, wp_name, useTomTom)
   end
 end

--- a/IPPinDB.lua
+++ b/IPPinDB.lua
@@ -611,21 +611,30 @@ IPUIPinDB = {
  
 	[1550]={ --[[ Shadowlands ]]--
 		-- Ardenweald 
-		{54.446888, 86.067420, {1188}}, -- De Other Side 
-		{44.641620, 82.380521, {1184}}, -- Mists of Tirna Scithe 
+		{54.446888, 86.067420, {1188}}, -- De Other Side
+		{44.641620, 82.380521, {1184}}, -- Mists of Tirna Scithe
 
 		-- Maldraxxus 
-		{64.926732, 26.361662, {1183}}, -- Plaguefall 
-		{63.286728, 23.205620, {1187}}, -- Theater of Pain 
+		{64.926732, 26.361662, {1183}}, -- Plaguefall
+		{63.286728, 23.205620, {1187}}, -- Theater of Pain
 
 		-- Bastion 
-		{74.077868, 52.558160, {1186}}, -- Spires of Ascension 
+		{74.077868, 52.558160, {1186}}, -- Spires of Ascension
 		{68.996882, 59.912443, {1182}}, -- The Necrotic Wake 
 
 		-- Revendreth 
 		{31.328863, 52.883035, {1185}}, -- Halls of Atonement 
-		{24.945801, 48.466653, {1189}}, -- Sanguine Depths 
-		{23.900000, 51.100000, {1190}}, --Castle Nathria
+		{24.945801, 48.466653, {1189}}, -- Sanguine Depths
+		{23.900000, 51.100000, {1190}}, -- Castle Nathria
+		
+		-- Maw
+		{28.100000, 09.200000, {1193}}, -- Sanctum of Domination
+		
+		-- Tazavesh, the Veiled Market
+		{31.940000, 76.010000, {1194}}, -- Tazavesh, the Veiled Market
+		
+		-- Zereth Mortis
+		{89.000000, 80.000000, {1195}}, -- Sepulcher of the First Ones
 		
     }
 }

--- a/IPPinDB.lua
+++ b/IPPinDB.lua
@@ -3,56 +3,51 @@ IPUIContinentMapDB = {12, 13, 101, 113, 424, 572, 619, 905, 875, 876, 1550}
 IPUIPinDB = {
 
 	[12]={ --[[ KALIMDOR ]]--
-		{58.91, 85.31, {251,255,279,185,186,184,750,187}, "Caverns of Time"}, -- caverns of time
-		{53.43, 36.49, {78}}, --firelands
-		{50.49, 94.50, {69}}, --lost city tol'vir
-		{51.26, 92.58, {70}}, --halls of origination
-		{52.66, 96.61, {68}}, --vortex pinnacle
-		{45.51, 97.37, {74}}, --throne four winds
-
-		{57, 71.14, {760}}, --onyxia
-
-		{41.81, 84.35, {743}}, -- ruins of ahnqiraj
-		{40.28, 83.97, {744}}, -- temple of ahnqiraj
-
-		{54.19, 79.95, {241}}, -- zul'farrak
-
-
-		{58.53, 45.10, {226}}, -- ragefire chasm
-		{51.64, 52.95, {240}}, -- wailing caverns
-		{43.98, 36.29, {227}}, -- blackfathom deeps
-		{39.13, 57.55, {232}}, -- maraudon
-		{51.13, 69.61, {234}}, -- razorfen kraul
-		{53.3, 72.48, {233}}, -- razorfen downs
-		{41.94, 66.74, {230}}, -- diremaul
+		-- accuracy updated by fuba
+		{59.334832, 83.454406, {251,255,279,185,186,184,750,187}, "Caverns of Time"}, -- Caverns of ime	
+		
+		{58.366149, 42.790913, {226}}, -- Ragefire Chasm
+		{52.150148, 53.519964, {240}}, -- Wailing Caverns 
+		{54.301107, 33.964998, {78}}, -- Firelands 
+		{51.370823, 91.793716, {70}}, -- Halls of Origination 
+		{49.928331, 93.700117, {69}}, -- Lost City of the Tol'vir 
+		{52.651453, 97.099590, {68}}, -- The Vortex Pinnacle 
+		{49.029613, 90.299171, {1180}}, -- Ny'alotha, the Waking City 
+		{42.288864, 84.485090, {743}}, -- Ruins of Ahn'Qiraj 
+		{40.952015, 83.741444, {744}}, -- Temple of Ahn'Qiraj 
+		{45.970976, 96.607947, {74}}, -- Throne of the Four Winds 
+		{53.143901, 69.132304, {233}}, -- Razorfen Downs 
+		{50.905335, 68.369913, {234}}, -- Razorfen Kraul 
+		{42.830366, 67.436111, {230}}, -- Dire Maul 
+		{56.475580, 69.295347, {760}}, -- Onyxia's Lair 
+		{43.977249, 33.290136, {227}}, -- Blackfathom Deeps 
+		{54.286242, 78.018594, {241}}, -- Zul'Farrak 
+		{38.443625, 55.972254, {232}}, -- Maraudon 
 
 	},
 
 	[13]={ --[[ EASTERN KINGDOMS ]]--
-		{50.87, 36.87, {246}}, --scholomance
-		{46.15, 31.12, {311,316}, "Scarlet Monastery"}, --scarlet monastery
-		{46.79, 69.61, {228,229,66,559,742,741,73}, "Blackrock Mountain"}, --blackrock mountain
-		{47.94, 84.93, {76}}, --zul'gurub
-		{57.26, 25, {77}}, --zul'aman
-		{31.85, 61.76, {65}}, --throne of the tides
-		{53.81, 55.44, {71}}, --grim batol
-		{55.6, 59.46, {72}}, --bastion of twilight
-		{35, 51.61, {75}}, --baradin hold
-
-		{49.85, 81.29, {745,860}, "Karazhan"}, -- karazhan
-
-
-		{54.7, 4.51, {752}}, -- sunwell plateau
-		{56.23, 3.17, {249}}, -- magisters terrace
-
-
-		{54.45, 79.37, {237}}, -- sunken temple
-		{53.17, 30.36, {236}}, -- stratholme
-		{52.73, 65.19, {239}}, -- uldaman
-		{40.92, 41.66, {64}}, -- shadowfang keep
-		{43.21, 60.42, {231}}, -- gnomeregan
-		{41.3, 82.63, {63}}, -- deadmines
-		{42.45, 71.14, {238}}, -- stockade
+		-- accuracy updated by fuba
+		{46.565998, 30.408025, {316, 311}}, -- Scarlet Monastery & Scarlet Halls
+		{47.533423, 68.936825, {228,229,66,559,742,741,73}, "Blackrock Mountain"}, --blackrock mountain
+		
+		{42.557746, 73.508930, {238}}, -- The Stockade 
+		{58.319151, 24.770936, {77}}, -- Zul'Aman 
+		{55.341327, 3.754913, {752}}, -- Sunwell Plateau 
+		{56.705868, 2.539425, {249}}, -- Magisters' Terrace 
+		{31.329137, 61.764145, {65}}, -- Throne of the Tides 
+		{47.579545, 85.058224, {76}}, -- Zul'Gurub 
+		{49.532115, 82.105708, {745}}, -- Karazhan 
+		{40.855193, 81.943280, {63}}, -- The Deadmines 
+		{52.440280, 63.592976, {239}}, -- Uldaman 
+		{53.071213, 56.113398, {71}}, -- Grim Batol 
+		{54.997647, 59.190130, {72}}, -- Bastion of Twilight 
+		{35.187650, 51.994443, {75}}, -- Baradin Hold 
+		{40.766543, 42.028379, {64}}, -- Shadowfang Keep 
+		{50.946778, 36.533028, {246}}, -- Scholomance 
+		{52.897459, 28.662109, {236}}, -- Stratholme 
+		{43.131673, 60.258794, {231}}, -- Gnomeregan 
+		{54.001498, 79.585975, {237}}, -- The Temple of Atal'hakkar 
 
 	},
 
@@ -164,18 +159,29 @@ IPUIPinDB = {
 	},
 
 	[101]={ --[[ OUTLAND ]]--
-		{55.72, 53.33, {248,256,259,747}, "Hellfire Citadel"}, -- hellfire ramparts, blood furnace, shattered halls, magtheridons lair
-		{34.54, 44.91, {260,262,261,748}, "Coilfang Reservoir"}, --slave pens, underbog, steamvault, serpentshrine cavern
-		{72.83, 81.48, {751}}, -- black temple
-		{43.85, 19.45, {746}}, -- gruuls lair
-		{44.62, 78.80, {247}}, -- auchenai crypts
-		{47.17, 79.37, {252}}, -- sethekk halls
-		{45.90, 80.52, {253}}, -- shadow labyrinth
-		{46.15, 77.84, {250}}, -- mana tombs
-		{69.64, 25.57, {258}}, -- the mechanar
-		{69.51, 22.32, {254}}, -- the arcatraz
-		{67.21, 23.08, {257}}, -- the botanica
-		{68.23, 24.23, {749}}, -- the eye
+		{56.864411, 53.081107, {248,256,259,747}, "Hellfire Citadel"}, -- hellfire ramparts, blood furnace, shattered halls, magtheridons lair
+		{35.100651, 43.017900, {260,262,261,748}, "Coilfang Reservoir"}, --slave pens, underbog, steamvault, serpentshrine cavern
+	
+		{66.755688, 21.568245, {254}}, -- The Arcatraz 
+		{65.531957, 25.364953, {258}}, -- The Mechanar 
+		{65.902364, 20.709950, {257}}, -- The Botanica 
+		{66.509819, 23.475188, {749}}, -- The Eye 
+		{45.217413, 19.633377, {746}}, -- Gruul's Lair 
+		{46.112078, 76.546884, {250}}, -- Mana-Tombs 
+		{44.576973, 78.875500, {247}}, -- Auchenai Crypts 
+		{46.107042, 81.220865, {253}}, -- Shadow Labyrinth 
+		{72.598433, 81.309861, {751}}, -- Black Temple 
+		{47.644269, 78.878593, {252}}, -- Sethekk Halls 
+		
+		--{56.907701, 52.634275, {259}}, -- The Shattered Halls 		
+		--{56.864411, 53.081107, {248}}, -- Hellfire Ramparts 
+		--{56.302017, 52.597624, {256}}, -- The Blood Furnace 
+		--{56.467259, 52.905875, {747}}, -- Magtheridon's Lair 
+		
+		--{34.252650, 43.720645, {260}}, -- The Slave Pens 
+		--{35.754776, 43.290305, {262}}, -- The Underbog 
+		--{34.688902, 42.974162, {261}}, -- The Steamvault 
+		--{35.100651, 43.017900, {748}}, -- Serpentshrine Cavern 
 	},
 
 
@@ -219,24 +225,39 @@ IPUIPinDB = {
 
 
 	[113]={ --[[ NORTHREND ]]--
-		{64.15, 55.44, {273}}, --draktharon keep
-		{77.55, 30.74, {274}}, --gundrak
-		{11.94, 57.16, {281,282,756}, "The Nexus"}, --nexus, oculus, eye of eternity
-		{41, 57.74, {272,271}, "Azjol-Nerub"}, -- azjol-nerub,ahnkahet
-		{58.53, 53.33, {754}}, --naxxramas
-		{50.36, 55.44, {755,761}, "Wyrmrest Temple"}, --wymrest temple
-		{80.36, 77.27, {285}}, --utgarde keep
-		{80.49, 74, {286}}, --utgarde pinnacle
+		{14.464706, 57.831287, {281,282,756}, "The Nexus"}, -- The Nexus, The Oculus , The Eye of Eternity 
+		{40.305239, 59.160542, {272,271}, "Azjol-Nerub"}, --Azjol-Nerub, Ahn'kahet: The Old Kingdom
+		{50.433493, 61.013103, {755,761}, "Wyrmrest Temple"}, -- The Obsidian Sanctum, The Ruby Sanctum 
+		{41.334301, 43.610418, {280,278,276}, "Icecrown Citadel (Instances)"}, --forge of souls, pit of saron, halls of reflection
+		{75.265151, 33.042300, {274}}, -- Gundrak 
+		{59.155452, 15.341455, {275}}, -- Halls of Lightning 
+		{47.613448, 20.176327, {284}}, -- Trial of the Champion 
+		{57.737643, 13.950807, {759}}, -- Ulduar 
+		{47.943360, 20.627499, {757}}, -- Trial of the Crusader 
+		{56.989229, 17.385972, {277}}, -- Halls of Stone 
+		{36.742854, 44.754410, {753}}, -- Vault of Archavon 
+		{40.833014, 42.360616, {758}}, -- Icecrown Citadel (Raid)		
+		{77.813774, 79.499596, {285}}, -- Utgarde Keep 
+		{77.602148, 78.531313, {286}}, -- Utgarde Pinnacle 
+		{62.605429, 50.409472, {273}}, -- Drak'Tharon Keep 
+		{58.568549, 59.221923, {754}}, -- Naxxramas 
 
-		{36.32, 37.63, {280,278,276}, "Icecrown Citadel"}, --forge of souls, pit of saron, halls of reflection
-		{45, 18.3, {284}}, --trial of champion
-		{46.79, 19.64, {757}}, --trial of crusader
-		{38.24, 36.10, {758}}, --ICC
-		{56.75, 12.74, {275}}, --halls of lightning
-		{60.83, 12.94, {277}}, --halls of stone
-		{58.79, 14.28, {759}}, --ulduar
-		{35.5, 45.29, {753}}, --vault of archavon
-		{48.96, 40.12, {283}}, --violet hold
+
+		-- Hubs
+		--{15.074217, 57.911932, {281}}, -- The Nexus 
+		--{14.464706, 57.831287, {282}}, -- The Oculus 
+		--{14.746982, 57.609475, {756}}, -- The Eye of Eternity 		
+		
+		--{50.433493, 61.013103, {755}}, -- The Obsidian Sanctum 
+		--{50.829339, 59.694761, {761}}, -- The Ruby Sanctum 
+		
+		--{41.016567, 59.422231, {271}}, -- Ahn'kahet: The Old Kingdom 
+		--{40.305239, 59.160542, {272}}, -- Azjol-Nerub 
+		
+		--{41.334301, 43.610418, {276}}, -- Halls of Reflection 
+		--{41.140878, 43.889314, {278}}, -- Pit of Saron 
+		--{41.180056, 43.282163, {280}}, -- The Forge of Souls 
+		
 	},
 
 	[70]={ --[[ Dustwallow Marsh ]]--
@@ -347,17 +368,18 @@ IPUIPinDB = {
 	},
 
 	[424]={ --[[ PANDARIA ]]--
-		{68.49, 50.85, {313}},
-		{48.07, 71.06, {302}},
-		{22.15, 48.74, {324}},
-		{32.62, 66.74, {330}}, --heart of fear
-		{43.18, 28.65, {312}}, -- Shadow-Pan Monastery
-		{49, 26.53, {317}},
-		{55.98, 52.38, {321}},
-		{43.85, 57.55, {303}},
-		{52.41, 53.14, {369}},
-		{57.89, 53.91, {320}},
-		{23.56, 7.77, {362}},
+		-- accuracy updated by fuba
+		{40.029776, 29.399705, {312}}, -- Shado-Pan Monastery 
+		{23.629445, 50.682461, {324}}, -- Siege of Niuzao Temple 
+		{48.269910, 71.458638, {302}}, -- Stormstout Brewery 
+		{30.269867, 62.952209, {330}}, -- Heart of Fear 
+		{43.006974, 57.881606, {303}}, -- Gate of the Setting Sun 
+		{56.775784, 55.335325, {320}}, -- Terrace of Endless Spring 
+		{52.457952, 52.673072, {369}}, -- Siege of Orgrimmar 
+		{53.583229, 51.131046, {321}}, -- Mogu'shan Palace 
+		{24.192643, 9.327094, {362}}, -- Throne of Thunder 
+		{72.337890, 55.303389, {313}}, -- Temple of the Jade Serpent 
+		{49.266016, 26.054907, {317}}, -- Mogu'shan Vaults 
 	},
 
 	[371]={ --[[ The Jade Forest ]]--
@@ -402,16 +424,17 @@ IPUIPinDB = {
 
 
 	[572]={ --[[ DRAENOR ]]--
-		{34, 26.72, {385}},
-		{58, 46.82, {669}},
-		{38.62, 62.91, {547}},
-		{54.45, 69.61, {537}},
-		{43.98, 73.06, {476}},
-		{51.64, 24.62, {536}},
-		{49.21, 15.23, {558}},
-		{53.04, 29.02, {556}},
-		{49.98, 24.04, {457}},
-		{20.24, 50.08, {477}},
+		--
+		{57.179046, 46.857738, {669}}, -- Hellfire Citadel 
+		{40.332538, 64.017260, {547}}, -- Auchindoun 
+		{53.258443, 68.833363, {537}}, -- Shadowmoon Burial Grounds 
+		{34.262162, 25.926590, {385}}, -- Bloodmaul Slag Mines 
+		{42.744762, 73.677135, {476}}, -- Skyreach 
+		{21.138650, 50.946498, {477}}, -- Highmaul 
+		{50.109494, 20.362067, {457}}, -- Blackrock Foundry 
+		{52.991092, 27.000123, {556}}, -- The Everbloom 
+		{51.401901, 21.991462, {536}}, -- Grimrail Depot 
+		{47.897261, 15.449053, {558}}, -- Iron Docks 
 	},
 
 	[525]={ --[[ Frostfire Ridge ]]--
@@ -441,24 +464,28 @@ IPUIPinDB = {
 
 
 	[619]={ --[[ BROKEN ISLES ]]--
-		{47, 66, {777}}, --Assault on Violet Hold
-		{37, 26, {762}}, --Darkheart Thicket
-		{36, 28, {768}}, --Emerald Nightmare
-		{39, 57, {716}}, --Eye of Azshara
-		{64, 38, {721,861}, "Halls of Valor"}, --Trial of Valor
-		{47, 28, {767}}, --Neltharion's Lair
-		{29, 36, {740}}, --Black Rook Hold
-		{56, 60, {900}}, --Cathedral of Eternal Night
-		{49, 50, {800}}, --Court of Stars
-		{60, 31, {727}}, --Maw of Souls
-		{47, 51, {726}}, --The Arcway
-		{34, 72, {707}}, --Vault of the Wardens
-		{48, 49, {786}}, --The Nighthold
-		{56, 64, {875}}, --Tomb of Sargeras
+		{45.5, 65.4, {777}}, --Assault on Violet Hold
+		--{64, 38, {721,861}, "Halls of Valor"}, --Trial of Valor
 
 		{90, 10, {945}}, --Seat of the Triumvirate
 		{83, 22, {946}}, --Antorus, the Burning Throne
+		
+		{47.082645, 47.276622, {786}}, -- The Nighthold 
+		{49.157399, 49.704754, {800}}, -- Court of Stars 
+		{46.328253, 48.518091, {726}}, -- The Arcway 
+		{47.326821, 28.105956, {767}}, -- Neltharion's Lair 
+		{56.687760, 61.282229, {900}}, -- Cathedral of Eternal Night 
+		{56.522393, 62.224877, {875}}, -- Tomb of Sargeras 
+		{35.123855, 29.253191, {768}}, -- The Emerald Nightmare 
+		{35.844809, 27.464533, {762}}, -- Darkheart Thicket 
+		{29.432726, 33.010352, {740}}, -- Black Rook Hold 
+		{58.983743, 30.600971, {727}}, -- Maw of Souls 
+		{34.165710, 72.176051, {707}}, -- Vault of the Wardens 
+		{38.747579, 57.827079, {716}}, -- Eye of Azshara 
+		{65.197098, 38.319182, {721}}, -- Halls of Valor 
+		{64.727789, 39.032668, {861}}, -- Trial of Valor 		
 	},
+	
 	[630]={ --[[ Azsuna ]]--
 	},
 	[634]={ --[[ Stormheim ]]--
@@ -483,34 +510,33 @@ IPUIPinDB = {
 
 	[875]={ --[[ Zandalar ]]--
 		{47, 79, {1012}, "Alliance"}, --The MOTHERLODE!!! (Alliance)
-		{57, 72, {1012}, "Horde"}, --The MOTHERLODE!!! (Horde)
-		{50, 65, {968}, "FactionSpecific"}, --Atal'Dazar
-		{47, 64, {1041}}, --Kings' Rest
-		{40, 20, {1030}, "FactionSpecific"}, --Temple of Sethraliss
-		{58.19, 35.72, {1022}, "FactionSpecific"}, --The Underrot
-		{59.12, 34.92, {1031}}, --Uldir
+		{56.827933, 71.638525, {1012}, "Horde"}, --The MOTHERLODE!!! (Horde)
+		{49.046028, 59.036940, {968}, "FactionSpecific"}, --Atal'Dazar
+		{45.364636, 59.034383, {1041}}, --Kings' Rest
+		{40.801734, 14.818758, {1030}, "FactionSpecific"}, --Temple of Sethraliss
+		{58.347869, 35.865015, {1022}, "FactionSpecific"}, --The Underrot
+		{59.458768, 35.239428, {1031}}, --Uldir
 		
-		{55.13, 53.31, {1176}, "Horde"}, --Battle of Dazar'alor
+		{55.687213, 53.126276, {1176}, "Horde"}, --Battle of Dazar'alor
 		
-		{86.11, 11.01, {1179}}, --The Eternal Palace
+		{86.11, 11.01, {1179}}, --The Eternal Palacem
 	},
 
 	[876]={ --[[ Kul Tiras ]]--
 		{60, 51, {1023}, "Alliance"}, --Siege of Boralus (Alliance)
-		{68, 66, {1023}, "Horde"}, --Siege of Boralus (Horde)
-		{67.16, 80.46, {1001}, "FactionSpecific"}, --Freehold
-		{77, 62, {1002}, "FactionSpecific"}, --Tol Dagor
-		{30, 55, {1021}, "FactionSpecific"}, --Waycrest Manor
-		{65, 14, {1036}, "FactionSpecific"}, --Shrine of the Storm
+		{69.292617, 65.077150, {1023}, "Horde"}, --Siege of Boralus (Horde)
+		{67.187595, 80.774778, {1001}, "FactionSpecific"}, --Freehold
+		{77.641767, 62.347782, {1002}, "FactionSpecific"}, --Tol Dagor
+		{31.653005, 53.677452, {1021}, "FactionSpecific"}, --Waycrest Manor
+		{65.915036, 15.108192, {1036}, "FactionSpecific"}, --Shrine of the Storm
 		
 		{61.25, 52.20, {1176}, "Alliance"}, --Battle of Dazar'alor
 		
-		{67.16, 24.82, {1177}}, --Crucible of Storms
+		{68.211877, 23.901308, {1177}}, --Crucible of Storms
 
-		{19.86, 26.75, {1178}}, --Operation: Mechagon
+		{19.875503, 27.037364, {1178}}, --Operation: Mechagon
 
 		{86.11, 11.01, {1179}}, --The Eternal Palace
-
 	},
 
 	[862]={ --[[ Zuldazar ]]--
@@ -583,20 +609,23 @@ IPUIPinDB = {
 	},
  
  
-     [1550]={ --[[ Shadowlands ]]--
-        {69, 60, {1182}}, --The Necrotic Wake
-        {74, 52, {1186}}, --Spires of Ascension
-        
-        {65, 26, {1183}}, --Plaguefall
-        {64, 22, {1187}}, --Theater of Pain
-        
-        {54, 86, {1188}}, --De Other Side
-        {45, 82, {1184}}, --Mists of Tirna Scithe
+	[1550]={ --[[ Shadowlands ]]--
+		-- Ardenweald 
+		{54.446888, 86.067420, {1188}}, -- De Other Side 
+		{44.641620, 82.380521, {1184}}, -- Mists of Tirna Scithe 
 
-        {31, 53, {1185}}, --Halls of Atonement
-        {27, 48, {1189}}, --Sanguine Depths
+		-- Maldraxxus 
+		{64.926732, 26.361662, {1183}}, -- Plaguefall 
+		{63.286728, 23.205620, {1187}}, -- Theater of Pain 
 
-        {23, 50, {1190}}, --Castle Nathria
+		-- Bastion 
+		{74.077868, 52.558160, {1186}}, -- Spires of Ascension 
+		{68.996882, 59.912443, {1182}}, -- The Necrotic Wake 
 
+		-- Revendreth 
+		{31.328863, 52.883035, {1185}}, -- Halls of Atonement 
+		{24.945801, 48.466653, {1189}}, -- Sanguine Depths 
+		{23.900000, 51.100000, {1190}}, --Castle Nathria
+		
     }
 }

--- a/IPPinDB.lua
+++ b/IPPinDB.lua
@@ -1,4 +1,4 @@
-IPUIContinentMapDB = {12, 13, 101, 113, 424, 572, 619, 905, 875, 876, 1550}
+IPUIContinentMapDB = {12, 13, 101, 113, 424, 572, 619, 905, 875, 876, 1550, 1978}
 
 IPUIPinDB = {
 
@@ -636,5 +636,24 @@ IPUIPinDB = {
 		-- Zereth Mortis
 		{89.000000, 80.000000, {1195}}, -- Sepulcher of the First Ones
 		
-    }
+	},
+	 
+	[1978]={ --[[ Dragon Isles  ]]--
+		-- The Walking Shore
+		{42.143745018467, 35.674487808132, {1199}}, -- Neltharus
+		{52.909352674978, 41.753505978421, {1202}}, -- Ruby Life Pools
+
+		-- Taldraszus
+		{63.281882669086, 41.734546447436, {1201}}, -- Algeth'ar Academy
+		{63.654679188667, 48.978011127175, {1204}}, -- Halls of Infusion
+		{69.870329020185, 46.807002765369, {1200}}, -- Vault of the Incarnates (Raid)
+
+		-- The Azure Span		
+		{47.421586086518, 82.733546450360, {1203}}, -- The Azure Vault
+		{35.719918658531, 76.005899033001, {1196}}, -- Brackenhide Hollow
+
+		-- Ohn'ahran Plains
+		{43.678347131592, 52.886746779309, {1198}}, -- The Nokhud Offensive
+		
+	}
 }


### PR DESCRIPTION
Hi there!
I've added Support for TomTom and Built-In Waypoint System if TomTom is not available when "Right-Click" your Map Pins on a at the Continent Map.  
Also updated the Accuracy of most Dungeon Entrances for the Continent Map!

Maybe you don't like where i put the new functions because you got a better structure then i made :P

You can also add this feature on the Original Dungeon Entrance Pins.  
I've done this in my own little "myself" AddOn ;)  
The biggest problem at this point -> you need to "replace" a Blizzard function to get it work properly!  
A hook will not prevent from open the Encounter Journal and will close the Map instantly :(

Because of this i did not add it in the Pull Request, maybe you don't like it this way.  

Anyway, here is the Code for "Waypoints on Original Dungeon Entrance Pins":
```
-- Waypoint for Dungeon Entrance Pins
local function WaypointDungeonEntrancePinMixin(self, button)
	local useWaypoints = true
	local useTomTom = true
	local wp_mapid, wp_x, wp_y, wp_name
	useTomTom = useTomTom and (TomTom ~= nil) or false

	if (button == "LeftButton" and IsShiftKeyDown() and useWaypoints == true) then
		if IsControlKeyDown() then useTomTom = false end
		local uiMapID = self:GetMap():GetMapID();
		local journalInstanceID = self.journalInstanceID		
		
		local dungeonEntrances = C_EncounterJournal.GetDungeonEntrancesForMap(uiMapID);
		for i, dungeonEntranceInfo in ipairs(dungeonEntrances) do
			if dungeonEntranceInfo.journalInstanceID == journalInstanceID then
				wp_mapid = uiMapID
				wp_x = dungeonEntranceInfo.position.x
				wp_y = dungeonEntranceInfo.position.y
				wp_name = dungeonEntranceInfo.name or "Waypoint"
			end
		end
		
		-- if no "dungeonEntranceInfo" is found, use Pin itself as Source
		if (not wp_mapid) then
			wp_mapid = self:GetMap():GetMapID();
			wp_x, wp_y = self:GetPosition()
			wp_name = self.name or "Waypoint"
		end
	else -- if not
		EncounterJournal_LoadUI();
		EncounterJournal_OpenJournal(nil, self.journalInstanceID);
	end
	
	if (button == "LeftButton" and IsShiftKeyDown() and useWaypoints == true) and wp_mapid and wp_x and wp_y and wp_name then
		AddWaypoint(wp_mapid, wp_x, wp_y, wp_name, useTomTom)
	end
end
_G.DungeonEntrancePinMixin.OnMouseClickAction = WaypointDungeonEntrancePinMixin
```
this also requires the function `AddWaypoint` i've added in your "IPInstancePortalPinTemplate.lua"

Hopefully you like the changes and maybe we will see Waypoint support soon as Release Version ;)

and sorry for the "Wall of Text" :P

greetings,
fuba